### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ systemctl enable --now drbd-reactor-reload.path
 # Building
 
 This is a Rust application. If you have a Rust toolchain and `cargo` installed (via distribution packages or
-[rustup](https://rustup.sh)) you can build it via:
+[rustup](https://rustup.rs)) you can build it via:
 
 ```
 cargo build


### PR DESCRIPTION
https://rustup.sh seems to be a malicious link. https://rustup.rs is the correct link for the tool in question